### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -98,7 +98,7 @@ class syntax_plugin_explain extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern($re, $mode, 'plugin_explain');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         /* Supply the matched text in any case. */
         $data = array('content' => $match);
         foreach (array_keys($this->map) as $rxmatch) {
@@ -113,7 +113,7 @@ class syntax_plugin_explain extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($format, &$renderer, $data) {
+    function render($format, Doku_Renderer $renderer, $data) {
         if(is_null($data['desc'])) {
             $renderer->doc .= hsc($data['content']);
             return true;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
